### PR TITLE
Adicionado nova validação

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ Aplicado padrão das PSR.
 via composer.json
 
 ```
-"brunoconte3/validation": "4.29.0"
+"brunoconte3/validation": "4.30.0"
 ```
 
 via composer.
@@ -239,6 +239,7 @@ Com os validadores fileName, maxFile, maxUploadSize, mimeType, minFile, minUploa
 - required: `Define o campo como obrigatório.`
 - requiredFile: `Define o campo do tipo 'File', como obrigatório.`
 - rgbColor: `Verifica se a string possui um RGB Color válido.`
+- timestamp: `Verifica se o valor é um timestamp válido (aceita formato Brasileiro ou Americano).`
 - upper: `Verifica se todos os caracteres são maiúsculas.`
 - url: `Verifica se o valor é um endereço de URL válida.`
 - zipCode: `Verifica se o valor corresponde ao formato de um CEP.`
@@ -268,33 +269,34 @@ require 'vendor/autoload.php';
 
 use brunoconte3\Validation\Format;
 
-echo Format::companyIdentification('39678379000129') . '<br>'; //CNPJ ==> 39.678.379/0001-29
+Format::companyIdentification('39678379000129') . '<br>'; //CNPJ ==> 39.678.379/0001-29
 Format::convertTypes($datas, $rules); //Converte o valor para o tipo correto dele ['bool', 'float', 'int', 'numeric',]
-echo Format::currency('1123.45') . '<br>'; //Moeda padrão BR ==>  1.123,45
-echo Format::currencyUsd('1123.45') . '<br>'; //Moeda padrão USD ==> 1,123.45
-echo Format::dateAmerican('12-05-2020') . '<br>'; //Data ==>  2020-05-12
-echo Format::emptyToNull(['test' => 'null']) . '<br>'; //['test' => null]
-echo Format::dateBrazil('2020-05-12') . '<br>'; //Data ==>  12/05/2020
-echo Format::identifier('73381209000') . '<br>';  //CPF ==>  733.812.090-00
-echo Format::identifierOrCompany('30720870089') . '<br>'; //CPF/CNPJ ==> 307.208.700-89
-echo Format::falseToNull(false) . '<br>'; //Retorna ==> null
-echo Format::lower('CArrO') . '<br>'; //Minusculo ==> carro - o segundo parametro escolhe o charset, UTF-8 default
+Format::convertTimestampBrazilToAmerican('15/04/2021 19:50:25'); //Converte formato Timestamp Brasil para Americana
+Format::currency('113', 'R$ ') . '<br>'; //Moeda padrão BR ==>  123,00 - o 2º parâmetro escolhe o label da Moeda
+Format::currencyUsd('1123.45') . '<br>'; //Moeda padrão USD ==> 1,123.45 - o 2º parâmetro escolhe o label da Moeda
+Format::dateAmerican('12-05-2020') . '<br>'; //Data ==>  2020-05-12
+Format::emptyToNull(['test' => 'null']) . '<br>'; //['test' => null]
+Format::dateBrazil('2020-05-12') . '<br>'; //Data ==>  12/05/2020
+Format::identifier('73381209000') . '<br>';  //CPF ==>  733.812.090-00
+Format::identifierOrCompany('30720870089') . '<br>'; //CPF/CNPJ ==> 307.208.700-89
+Format::falseToNull(false) . '<br>'; //Retorna ==> null
+Format::lower('CArrO') . '<br>'; //Minusculo ==> carro - o 2º parâmetro escolhe o charset, UTF-8 default
 //[Aplicar qualquer tipo de Mascara, aceita espaço, pontos e outros]
-echo Format::mask('#### #### #### ####', '1234567890123456') . '<br>'; //Mascara ==> 1234 5678 9012 3456
-echo Format::maskStringHidden('065.775.009.96', 3, 4, '*'); //Marcarar uma string ==> 065.***.009.96
-echo Format::onlyNumbers('548Abc87@') . '<br>'; //Retorna apenas números ==> 54887;
-echo Format::onlyLettersNumbers('548Abc87@') . '<br>'; //Retorna apenas letras e números ==> 548Abc87;
-echo Format::pointOnlyValue('1.350,45') . '<br>'; //Moeda para gravação no BD ==>  1350.45
-echo Format::removeAccent('Açafrão') . '<br>'; //Remove acentos e o caracter 'ç' ==> Acafrao
-echo Format::returnPhoneOrAreaCode('44999998888', false) . '<br>'; //Retorna apenas o número do telefone ==> 999998888
-echo Format::returnPhoneOrAreaCode('44999998888', true) . '<br>'; //Retorna apenas o DDD do telefone ==> 44
-echo Format::reverse('Abacaxi') . '<br>'; //Retorna string invertida ==> ixacabA
-echo Format::telephone('44999998888') . '<br>';  //Telefone ==> (44) 99999-8888
-echo Format::ucwordsCharset('aÇafrÃo maCaRRão') . '<br>'; //Primeira letra maiuscula ==> Açafrão Macarrão
-echo Format::upper('Moto') . '<br>'; //Mauiusculo ==> MOTO - o segundo parametro escolhe o charset, UTF-8 default
-echo Format::zipCode('87030585') . '<br>'; //CEP ==>  87030-585
-echo Format::writeDateExtensive('06/11/2020') . '<br>'; //Data por Extenso ==> sexta-feira, 06 de novembro de 2020
-echo Format::writeCurrencyExtensive(1.97) . '<br>'; //Moeda por Extenso ==> um real e noventa e sete centavos
+Format::mask('#### #### #### ####', '1234567890123456') . '<br>'; //Mascara ==> 1234 5678 9012 3456
+Format::maskStringHidden('065.775.009.96', 3, 4, '*'); //Marcarar uma string ==> 065.***.009.96
+Format::onlyNumbers('548Abc87@') . '<br>'; //Retorna apenas números ==> 54887;
+Format::onlyLettersNumbers('548Abc87@') . '<br>'; //Retorna apenas letras e números ==> 548Abc87;
+Format::pointOnlyValue('1.350,45') . '<br>'; //Moeda para gravação no BD ==>  1350.45
+Format::removeAccent('Açafrão') . '<br>'; //Remove acentos e o caracter 'ç' ==> Acafrao
+Format::returnPhoneOrAreaCode('44999998888', false) . '<br>'; //Retorna apenas o número do telefone ==> 999998888
+Format::returnPhoneOrAreaCode('44999998888', true) . '<br>'; //Retorna apenas o DDD do telefone ==> 44
+Format::reverse('Abacaxi') . '<br>'; //Retorna string invertida ==> ixacabA
+Format::telephone('44999998888') . '<br>';  //Telefone ==> (44) 99999-8888
+Format::ucwordsCharset('aÇafrÃo maCaRRão') . '<br>'; //Primeira letra maiuscula ==> Açafrão Macarrão
+Format::upper('Moto') . '<br>'; //Mauiusculo ==> MOTO - o 2º parâmetro escolhe o charset, UTF-8 default
+Format::zipCode('87030585') . '<br>'; //CEP ==>  87030-585
+Format::writeDateExtensive('06/11/2020') . '<br>'; //Data por Extenso ==> sexta-feira, 06 de novembro de 2020
+Format::writeCurrencyExtensive(1.97) . '<br>'; //Moeda por Extenso ==> um real e noventa e sete centavos
 
 $array = [
     0 => '1',
@@ -427,26 +429,26 @@ require 'vendor/autoload.php';
 use brunoconte3\Validation\Compare;
 
 //Retorna +30 (+30 dias de diferença)
-echo Compare::daysDifferenceBetweenData('31/05/2020', '30/06/2020') . '<br>'; //Aceita data Americana também
+Compare::daysDifferenceBetweenData('31/05/2020', '30/06/2020') . '<br>'; //Aceita data Americana também
 
 //Compara se a data inicial é menor que a data final => Retorna [bool]
-echo Compare::startDateLessThanEnd('30/07/2020', '30/06/2020') . '<br>'; //Aceita data Americana também
+Compare::startDateLessThanEnd('30/07/2020', '30/06/2020') . '<br>'; //Aceita data Americana também
 
 //Diferença entre horas ==> 01:36:28 [Horas exibe negativo e positivo a diferença]
-echo Compare::differenceBetweenHours('10:41:55', '12:18:23') . '<br>';
+Compare::differenceBetweenHours('10:41:55', '12:18:23') . '<br>';
 
 //Compara se a hora inicial é menor que a hora final (3º parâmetro, aceita mensagem customizada)
-echo Compare::startHourLessThanEnd('12:05:01', '10:20:01') . '<br>';
+Compare::startHourLessThanEnd('12:05:01', '10:20:01') . '<br>';
 
 //Compara a data com a data atual, e retorna a idade da pessoa
-echo Compare::calculateAgeInYears('20/05/1989');
+Compare::calculateAgeInYears('20/05/1989');
 
 //Compara igualdade dos campos, retorna booleano;
-//terceiro parametro opcional, false para não comparar caseSensitive, default true
-var_dump(Compare::checkDataEquality('AçaFrão', 'Açafrão'));
+//terceiro parâmetro opcional, false para não comparar caseSensitive, default true
+Compare::checkDataEquality('AçaFrão', 'Açafrão');
 
 //Compara se o conteudo desejado existe na String, retorna booleano
-var_dump(Compare::contains('AçaFrão', 'çaF'));
+Compare::contains('AçaFrão', 'çaF');
 
 ```
 
@@ -458,8 +460,6 @@ var_dump(Compare::contains('AçaFrão', 'çaF'));
 require 'vendor/autoload.php';
 
 use brunoconte3\Validation\Array;
-
-echo '<br><br>Manipular Arrays<hr>';
 
 $array = ['primeiro' => 15, 'segundo' => 25];
 var_dump(Arrays::searchKey($array, 'primeiro'));   // Procura chave no array, e retorna a posição ==> returns 0
@@ -528,6 +528,7 @@ echo Utility::captureClientIp(); //Retorna o IP do usuário, captura por camada 
 ```
 
 # Rodar os testes unitários
+
 vendor/bin/phpunit
 
 # Licença

--- a/Test/UnitTestFormat.php
+++ b/Test/UnitTestFormat.php
@@ -7,8 +7,6 @@ namespace brunoconte3\Test;
 use brunoconte3\Validation\Format;
 use PHPUnit\Framework\TestCase;
 
-use function PHPUnit\Framework\assertIsFloat;
-
 class UnitTestFormat extends TestCase
 {
     public function testCompanyIdentification(): void
@@ -109,11 +107,13 @@ class UnitTestFormat extends TestCase
     public function testCurrency(): void
     {
         $this->assertEquals('1.123,45', Format::currency('1123.45'));
+        $this->assertEquals('R$ 1.123,45', Format::currency('1123.45', 'R$ '));
     }
 
     public function testCurrencyUsd(): void
     {
         $this->assertEquals('1,123.45', Format::currencyUsd('1123.45'));
+        $this->assertEquals('Usd 1,123.45', Format::currencyUsd('1123.45', 'Usd '));
     }
 
     public function testReturnPhoneOrAreaCode(): void
@@ -229,5 +229,10 @@ class UnitTestFormat extends TestCase
         $this->assertArrayHasKey('name', Format::restructFileArray($fileUploadSingle)[0]);
         $this->assertArrayHasKey('name', Format::restructFileArray($fileUploadMultiple)[0]);
         $this->assertArrayHasKey('name', Format::restructFileArray($fileUploadMultiple)[1]);
+    }
+
+    public function testConvertTimestampBrazilToAmerican(): void
+    {
+        $this->assertEquals('2021-04-15 19:50:25', Format::convertTimestampBrazilToAmerican('15/04/2021 19:50:25'));
     }
 }

--- a/Test/UnitTestRule.php
+++ b/Test/UnitTestRule.php
@@ -654,4 +654,26 @@ class UnitTestRule extends TestCase
         $validator->set($array, $rules);
         $this->assertCount(2, $validator->getErros());
     }
+
+    public function testTimestamp(): void
+    {
+        $array = [
+            'dateHourAmericanError' => '2021-04-15 21:01',
+            'dateHourAmericanValid' => '2021-04-15 21:01:04',
+            'dateHourBrasilError' => '15/04/2021 21:01',
+            'dateHourBrasilValid' => '15/04/2021 21:01:04',
+        ];
+
+        $rules = [
+            'dateHourAmericanError' => 'timestamp',
+            'dateHourAmericanValid' => 'timestamp',
+            'dateHourBrasilError' => 'timestamp',
+            'dateHourBrasilValid' => 'timestamp',
+        ];
+
+        $validator = new Validator();
+        $validator->set($array, $rules);
+
+        $this->assertCount(2, $validator->getErros());
+    }
 }

--- a/src/Validation/Format.php
+++ b/src/Validation/Format.php
@@ -140,19 +140,19 @@ class Format extends FormatAux
     /**
      * @param float|int|string $value
      */
-    public static function currency($value): string
+    public static function currency($value, string $coinType = ''): string
     {
         $value = self::formatCurrencyForFloat($value);
-        return ((float) $value !== '') ? number_format((float) $value, 2, ',', '.') : '';
+        return ((float) $value !== '') ? $coinType . number_format((float) $value, 2, ',', '.') : '';
     }
 
     /**
      * @param float|int|string $value
      */
-    public static function currencyUsd($value): string
+    public static function currencyUsd($value, string $coinType = ''): string
     {
         $value = self::formatCurrencyForFloat($value);
-        return ((float) $value !== '') ?  number_format((float) $value, 2, '.', ',') : '';
+        return ((float) $value !== '') ?  $coinType . number_format((float) $value, 2, '.', ',') : '';
     }
 
     /**
@@ -313,5 +313,15 @@ class Format extends FormatAux
             }
         }
         return $arrayFile;
+    }
+
+    public static function convertTimestampBrazilToAmerican(string $dt): string
+    {
+        if (!ValidateDate::validateTimeStamp($dt)) {
+            throw new \Exception('Data não é um Timestamp!');
+        }
+
+        $dateTime = \DateTime::createFromFormat('d/m/Y H:i:s', $dt);
+        return $dateTime->format('Y-m-d H:i:s');
     }
 }

--- a/src/Validation/Rules.php
+++ b/src/Validation/Rules.php
@@ -102,6 +102,7 @@ class Rules
             'plate' => 'validatePlate',
             'regex' => 'validateRegex',
             'rgbColor' => 'validateRgbColor',
+            'timestamp' => 'validateTimestamp',
             'upper' => 'validateUpper',
             'url' => 'validateUrl',
             'noWeekend' => 'validateWeekend',

--- a/src/Validation/TraitRuleDate.php
+++ b/src/Validation/TraitRuleDate.php
@@ -34,6 +34,13 @@ trait TraitRuleDate
         }
     }
 
+    protected function validateTimestamp($rule = '', $field = '', $value = null, $message = null)
+    {
+        if (!ValidateDate::validateTimeStamp($value)) {
+            $this->errors[$field] = !empty($message) ? $message : "O campo $field não é um timestamp válido!";
+        }
+    }
+
     protected function validateWeekend($rule = '', $field = '', $value = null, $message = null)
     {
         if (strpos($value, '/') > -1) {

--- a/src/Validation/ValidateDate.php
+++ b/src/Validation/ValidateDate.php
@@ -2,6 +2,8 @@
 
 namespace brunoconte3\Validation;
 
+use DateTime;
+
 class ValidateDate
 {
     private static function validateYear(string $ano, string $mes, string $dia): bool
@@ -50,5 +52,19 @@ class ValidateDate
             }
             return false;
         }
+    }
+
+    public static function validateTimeStamp($date): bool
+    {
+        $format = 'Y-m-d H:i:s';
+        $d = DateTime::createFromFormat($format, $date);
+        $return = $d && $d->format($format) === $date;
+
+        if (!$return) {
+            $format = 'd/m/Y H:i:s';
+            $d = DateTime::createFromFormat($format, $date);
+            $return = $d && $d->format($format) === $date;
+        }
+        return $return;
     }
 }


### PR DESCRIPTION
- timestamp: `Verifica se o valor é um timestamp válido (aceita formato Brasileiro ou Americano).`

Métodos  Format::currency e Format::currencyUsd foi adicionado um 2º parâmetro opcional
Format::currency('113', 'R$ ') ; o 2º parâmetro opcional escolhe o label da Moeda pra exibir

Adicionado nova formatação
Format::convertTimestampBrazilToAmerican('15/04/2021 19:50:25'); ///Converte formato Timestamp Brasil para Americana